### PR TITLE
Fixed code to use the simple publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN:  ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a list of ESLint rules that are recommended for use with **Hubspot Marke
 
 1. Install as dev dependency
 
-```
+```shell
 npm i -D @hs-web-team/eslint-config-node
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-node",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "ISC",
       "dependencies": {
         "eslint": "^8.34.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "HubSpot Marketing WebTeam ESLint rules for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Changes

- Updated code to use the simple `npm publish` command instead of relying on the `JS-DevTools/npm-publish@v1` action.