### PR TITLE
Disable import/prefer-default-export rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = {
     'no-underscore-dangle': 0,
     'no-confusing-arrow': 0,
     'import/no-unresolved': 0,
+    'import/prefer-default-export': 0,
     'no-trailing-spaces': [2, { skipBlankLines: true }],
     'no-unused-expressions': [1, { allowTernary: true }],
     'max-len': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-node",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "ISC",
       "dependencies": {
         "eslint": "^8.55.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "HubSpot Marketing WebTeam ESLint rules for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary of Changes 📋

- disable [the `import/prefer-default-export` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md), as precursor to eventually enabling [the `import/no-default-export` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md)

