### PR TITLE
chore: allow commonly used underscore-dangle exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 .DS_Store
-.npmrc
 .claude/settings.local.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+preid=next
+save-exact=true

--- a/browser.js
+++ b/browser.js
@@ -13,6 +13,15 @@ const baseRules = {
   'no-plusplus': 0,
   'no-console': ['error', { allow: ['warn', 'error'] }],
   'no-confusing-arrow': 0,
+  'no-underscore-dangle': [
+    'error',
+    {
+      allow: [
+        '_hsg',
+        '_hsq',
+      ]
+    }
+  ],
   'no-trailing-spaces': ['error', { skipBlankLines: true }],
   'no-unused-expressions': ['warn', { allowTernary: true }],
   'max-len': [

--- a/index.js
+++ b/index.js
@@ -20,8 +20,6 @@ const baseRules = {
       allow: [
         '__dirname',
         '__filename',
-        '_hsg',
-        '_hsq',
       ]
     }
   ],

--- a/index.js
+++ b/index.js
@@ -14,7 +14,17 @@ const baseRules = {
   'comma-dangle': ['warn', 'always-multiline'],
   'arrow-parens': 0,
   'no-plusplus': 0,
-  'no-underscore-dangle': 0,
+  'no-underscore-dangle': [
+    'error',
+    {
+      allow: [
+        '__dirname',
+        '__filename',
+        '_hsg',
+        '_hsq',
+      ]
+    }
+  ],
   'no-confusing-arrow': 0,
   'import/no-unresolved': 0,
   'import/prefer-default-export': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "3.2.0",
+  "version": "3.2.1-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-node",
-      "version": "3.2.0",
+      "version": "3.2.1-0",
       "license": "ISC",
       "dependencies": {
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-node",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "ISC",
       "dependencies": {
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "3.2.0",
+  "version": "3.2.1-0",
   "description": "HubSpot Marketing WebTeam shared configurations for ESLint, Prettier, Stylelint, and Cypress",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "HubSpot Marketing WebTeam shared configurations for ESLint, Prettier, Stylelint, and Cypress",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
   Enables the \`no-underscore-dangle\` ESLint rule (previously disabled) across both the Node.js and browser configs, with a minimal set of explicit exceptions.

   **Node config (\`index.js\`):**
   - Allows \`__dirname\` and \`__filename\` — these are Node.js built-ins that commonly appear in CJS-compatible patterns

   **Browser config (\`browser.js\`):**
   - Allows \`_hsg\` and \`_hsq\` — HubSpot analytics globals that are browser-specific