### PR TITLE
feat: add selector-class-pattern stylelint rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -39,6 +39,13 @@
       {
         "camelCaseSvgKeywords": true
       }
+    ],
+    "selector-disallowed-list": [
+      ["/(?:^|[\\s>+~])\\s*\\.-[a-z]/i"],
+      {
+        "message": "Modifier classes (starting with '-') must not be standalone selectors; always combine with a base class (e.g., .prefix-element.-modifier or &.-modifier in nested rules)",
+        "severity": "error"
+      }
     ]
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,7 +11,13 @@
       }
     ],
     "scss/dollar-variable-pattern": null,
-    "selector-class-pattern": null,
+    "selector-class-pattern": [
+      "^-?[a-z0-9]([a-z0-9]|-(?!-))*$",
+      {
+        "message": "Class names should only contain lowercase alphanumeric characters and hyphens, with no consecutive hyphens",
+        "severity": "warning"
+      }
+    ],
     "declaration-block-no-redundant-longhand-properties": null,
     "alpha-value-notation": null,
     "scss/percent-placeholder-pattern": null,


### PR DESCRIPTION
1. Enforces class names use only lowercase alphanumeric characters and hyphens, with an optional single leading hyphen and no consecutive hyphens. Configured as a warning.
2. Disallows standalone modifier class selectors