### PR TITLE
feat: add prettier gherkin lint

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
+  "plugins": ["prettier-plugin-gherkin"],
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jiti": "^2.7.0",
         "js-yaml": "^4.1.1",
         "prettier": "^3.8.3",
+        "prettier-plugin-gherkin": "4.0.0",
         "typescript-eslint": "^8.60.0"
       },
       "bin": {
@@ -660,7 +661,6 @@
       "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.3.1.tgz",
       "integrity": "sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "class-transformer": "0.5.1",
         "reflect-metadata": "0.2.2"
@@ -2678,8 +2678,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -7242,6 +7241,24 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-gherkin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-gherkin/-/prettier-plugin-gherkin-4.0.0.tgz",
+      "integrity": "sha512-EBDwV1Ou9rG+seoh7jcwZ6sXXyHwsbUks5TeSyrlrLaTdz+/qYvnHuwY8rk7mb6/+M1ZGuY4/SiVc68ybwvJOA==",
+      "dependencies": {
+        "@cucumber/gherkin": "^39.1.0",
+        "@cucumber/messages": "^32.3.1",
+        "prettier": "^3.5.3"
+      }
+    },
+    "node_modules/prettier-plugin-gherkin/node_modules/@cucumber/gherkin": {
+      "version": "39.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-39.1.0.tgz",
+      "integrity": "sha512-pqmSO2bUWxJm3TbNrKXlDaHjL6c77+ez9kWmfCd9oRPeTRPEVH3spZvpAqdXYWOZYSNYwWFCAAeZ4RGpkauNoQ==",
+      "dependencies": {
+        "@cucumber/messages": ">=31.0.0 <33"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -7499,8 +7516,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jiti": "^2.7.0",
     "js-yaml": "^4.1.1",
     "prettier": "^3.8.3",
+    "prettier-plugin-gherkin": "4.0.0",
     "typescript-eslint": "^8.60.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Summary of Changes 📋

- Add `prettier-plugin-gherkin` to the `plugins` array in `.prettierrc.json` as a replacement for `gherkin-lint`, which carried an unresolved Dependabot vulnerability (protobufjs, alert #40)
- ⚠️ **Breaking change:** formatting rules differ from `gherkin-lint` so teams will need to run the prettier write script to reformat their `.feature` files after upgrading to this version (will create a major version for this upon approval.)
                                                                              
  **Key changes:**
  - Prettier config now includes Gherkin plugin for `.feature` file formatting support
                                                                                      
  ### Screenshot(s) or GIF(s) 📸
                                
  N/A - No UI changes
                     
  ### Production Checklist ✅
                                                                                                       
  - [ ] No additional steps required
                                                                                                       
  ### Relevant Links 🔗                                                                              
                       
  - [JIRA: OPS-1383](https://issues.hubspotcentral.com/browse/OPS-1383)
                                      