### PR TITLE
fix: remove scss rules dropped in stylelint-scss@7

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,10 +11,8 @@
       }
     ],
     "scss/dollar-variable-pattern": null,
-    "scss/at-import-no-partial-leading-underscore": null,
     "selector-class-pattern": null,
     "declaration-block-no-redundant-longhand-properties": null,
-    "scss/at-import-partial-extension": null,
     "alpha-value-notation": null,
     "scss/percent-placeholder-pattern": null,
     "scss/at-mixin-argumentless-call-parentheses": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-node",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "ISC",
       "dependencies": {
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-node",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "HubSpot Marketing WebTeam shared configurations for ESLint, Prettier, Stylelint, and Cypress",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
`scss/at-import-no-partial-leading-underscore` and `scss/at-import-partial-extension` were removed in stylelint-scss@7 (which stylelint-config-standard-scss@17 now requires). Setting them to null causes "Unknown rule" at startup even though they were just being disabled.