### PR TITLE
feat: warn on hardcoded color, font-size, and font-weight values

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,14 @@
 {
   "extends": "stylelint-config-standard-scss",
+  "plugins": ["stylelint-declaration-strict-value"],
   "rules": {
+    "scale-unlimited/declaration-strict-value": [
+      ["/color/", "fill", "stroke", "font-size", "font-weight"],
+      {
+        "ignoreValues": ["inherit", "initial", "unset", "revert", "currentColor", "transparent"],
+        "severity": "warning"
+      }
+    ],
     "length-zero-no-unit": null,
     "declaration-empty-line-before": null,
     "no-empty-source": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,7 +5,8 @@
     "scale-unlimited/declaration-strict-value": [
       ["/color/", "fill", "stroke", "font-size", "font-weight"],
       {
-        "ignoreValues": ["inherit", "initial", "unset", "revert", "currentColor", "transparent"],
+        "ignoreValues": ["inherit", "initial", "normal", "unset", "revert", "currentColor", "transparent"],
+        "message": "Expected a CSS custom property (var(--token)) or Sass variable ($var). For color opacity variants, use color-mix(in srgb, var(--token) 80%, transparent) instead of rgba().",
         "severity": "warning"
       }
     ],

--- a/examples/stylelint-usage.md
+++ b/examples/stylelint-usage.md
@@ -7,7 +7,7 @@ This package provides a shared Stylelint configuration for SCSS/CSS linting in H
 1. Install the package and stylelint dependencies:
 
 ```bash
-npm install --save-dev @hs-web-team/eslint-config-node stylelint stylelint-config-standard-scss
+npm install --save-dev @hs-web-team/eslint-config-node stylelint stylelint-config-standard-scss stylelint-declaration-strict-value
 ```
 
 ## Usage
@@ -136,7 +136,7 @@ To override rules for your project, add them to your `.stylelintrc.json`:
 If you get a module not found error, ensure you have installed all dependencies:
 
 ```bash
-npm install --save-dev stylelint stylelint-config-standard-scss
+npm install --save-dev stylelint stylelint-config-standard-scss stylelint-declaration-strict-value
 ```
 
 ### Conflicts with Prettier

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "cypress": "^15.16.0",
     "stylelint": "^17.1.1",
     "stylelint-config-standard": "^40.0.0",
-    "stylelint-config-standard-scss": "^17.0.0"
+    "stylelint-config-standard-scss": "^17.0.0",
+    "stylelint-declaration-strict-value": "^1.11.1"
   },
   "peerDependenciesMeta": {
     "stylelint": {
@@ -94,6 +95,9 @@
       "optional": true
     },
     "stylelint-config-standard-scss": {
+      "optional": true
+    },
+    "stylelint-declaration-strict-value": {
       "optional": true
     },
     "cypress": {


### PR DESCRIPTION
Builds on #34 (peer dep checking infrastructure).

## Summary

- Adds `scale-unlimited/declaration-strict-value` rule to `.stylelintrc.json` via the `stylelint-declaration-strict-value` plugin
- Warns (not errors) when `color`, `background-color`, `border-color` (any `/color/` property), `fill`, `stroke`, `font-size`, or `font-weight` use hardcoded literal values instead of CSS custom properties or Sass variables
- Allowed keywords: `inherit`, `initial`, `normal`, `unset`, `revert`, `currentColor`, `transparent`
- Warning message includes `color-mix()` guidance as the compliant alternative to `rgba()` opacity patterns
- Adds `stylelint-declaration-strict-value` as an optional peer dep; the postinstall script from #34 will warn at install time if it's missing

## Context

Surveyed four downstream projects (hs-cms-modules, portal-53, webteam-cms-portal, blog) before landing on this scope:
- All projects already use `--cl-*` custom properties and `$sass-variables` for these values — the rule reinforces existing practice
- `line-height` skipped: unitless ratios (`1.5`, `1.2`) are valid CSS and don't map cleanly to tokens
- Gradients (`linear-gradient`) skipped: the plugin checks the whole declaration value, so gradients using tokens internally would still be flagged as false positives
- `rgba()`/`hsla()` are warned on — zero compliant uses of `rgba(var(...))` found across all four projects, so no false positives

## Follow-up

- Convert `.stylelintrc.json` → JS config to enable per-property warning messages (color properties can get a targeted `color-mix()` hint; font properties get a cleaner message)
- At that point, consider rolling a first-party Stylelint rule with unit tests, which would also enable gradient color-stop inspection

## Test plan

- [ ] Install this package version in a downstream project and run stylelint — confirm warnings appear on hardcoded values
- [ ] Confirm `var(--cl-color-text-01)` and `$gray-90` do not warn
- [ ] Confirm `color: inherit`, `font-weight: normal`, `color: transparent` do not warn
- [ ] Confirm projects without stylelint installed see no postinstall output

🤖 AI-assisted draft — human review required