### PR TITLE
fix: add default export condition for cypress.config subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "./.stylelintrc.json": "./.stylelintrc.json",
     "./cypress.config": {
       "types": "./cypress.config.d.ts",
-      "require": "./cypress.config.cjs"
+      "require": "./cypress.config.cjs",
+      "default": "./cypress.config.cjs"
     },
     "./cypress": {
       "types": "./cypress/index.d.ts",


### PR DESCRIPTION
Add default export condition for cypress.config subpath

Without a "default" (or "import") condition, Node's ESM resolver cannot match the ./cypress.config subpath export, causing:

  Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './cypress.config'
  is not defined by "exports"

This surfaces in projects that load cypress.config.ts via ts (ESM). Adding "default" pointing to the existing .cjs file is