### PR TITLE
fix: allow modifier classes inside :is()/:not()/:where() with a base class

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -50,7 +50,10 @@
       }
     ],
     "selector-disallowed-list": [
-      ["/(?:^|[\\s>+~])\\s*\\.-[a-z]/i"],
+      [
+        "/(?<!:(?:is|not|where|matches)\\([^)]*)(?:^|[\\s>+~])\\s*\\.-[a-z]/i",
+        "/(?:^|[\\s>+~])\\s*:(?:is|not|where|matches)\\(\\s*\\.-[a-z]/i"
+      ],
       {
         "message": "Modifier classes (starting with '-') must not be standalone selectors; always combine with a base class (e.g., .prefix-element.-modifier or &.-modifier in nested rules)",
         "severity": "error"


### PR DESCRIPTION
## Summary

- Fixes a false positive in `selector-disallowed-list` where modifier classes (e.g. `.-mod-b`) were incorrectly flagged when used as additional arguments in `:is()`/`:not()`/`:where()` with a base class (e.g. `.base:is(.-mod-a, .-mod-b)`)
- Adds detection for the genuinely invalid case where `:is(.-modifier)` has no base class before it (e.g. `:is(.-mod-a, .-mod-b) .child`)

## Behaviour

| Selector | Before | After |
|---|---|---|
| `.base:is(.-mod-a, .-mod-b)` | ✖ false positive | ✔ passes |
| `.base:is(.-mod)` | ✔ passes | ✔ passes |
| `:is(.-mod-a, .-mod-b) .child` | ✔ passes (missed) | ✖ flagged |
| `.-standalone .bar` | ✖ flagged | ✖ flagged |

## How it works

Two patterns replace the previous single pattern:

1. Original pattern + **negative lookbehind** — skips matches where the modifier appears after a comma-space *inside* an already-open `:is()`/`:not()`/`:where()`/`:matches()`
2. **New pattern** — flags `:is(` (and siblings) when it appears at the start of a selector or after a combinator, meaning no base class precedes it

## Test plan

- [ ] Verify `.base:is(.-mod-a, .-mod-b) .child` no longer triggers `selector-disallowed-list`
- [ ] Verify `:is(.-mod-a, .-mod-b) .child` (no base class) is still flagged
- [ ] Verify `.-standalone .bar` is still flagged
- [ ] Verify `.base:not(.-mod-a, .-mod-b)` passes