### PR TITLE
chore: add dependabot config with grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    groups:
+      weekly-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` to consolidate the current individual dependabot PRs into a grouped PRs.

## What this does

- **Groups all version-update PRs** into one weekly Monday PR instead of one per package
- **Groups security-update PRs** into a single PR as well (created on alert, not on schedule)
- **Limits open PRs to 1** (`open-pull-requests-limit: 1`)
- **7-day cooldown** before a dependency is bumped again
- **Ignores major version bumps** — minor and patch only

No new update sources are added — this only changes how existing dependabot updates are batched.